### PR TITLE
Add quotes around sys.executable path

### DIFF
--- a/less/__init__.py
+++ b/less/__init__.py
@@ -2,8 +2,8 @@ import check50
 import sys
 import os
 
-RUN_TINY = f"{sys.executable} adventure.py Tiny"
-RUN_SMALL = f"{sys.executable} adventure.py Small"
+RUN_TINY = f"\"{sys.executable}\" adventure.py Tiny"
+RUN_SMALL = f"\"{sys.executable}\" adventure.py Small"
 
 room_1_name = "Outside building"
 room_1_description = ("You are standing at the end of a road before a "

--- a/more/__init__.py
+++ b/more/__init__.py
@@ -5,7 +5,7 @@ import sys
 less = check50.import_checks("../less")
 from less import *
 
-RUN_CROWTHER = f"{sys.executable} adventure.py Crowther"
+RUN_CROWTHER = f"\"{sys.executable}\" adventure.py Crowther"
 
 
 room_3_description = ("You are inside a building, a well house for a large "


### PR DESCRIPTION
Het probleem is dat de `sys.executable` ook nog spaties kan bevatten zoals het geval was bij één van de studenten. Deze PR voegt quotes toe om het pad in zowel de `less/__init__.py` als `more/__init__.py`. Ik heb dit getest met mijn fork op de desbetreffende student zijn laptop en het werkt, alle tests slagen nu ook bij hem.